### PR TITLE
Limit input on fail

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -42,8 +42,10 @@ class HomeController extends Controller
 
         $process->run();
 
+        $limitedInput = str_limit($input, 75);
+
         if (! $process->isSuccessful()) {
-            flash()->error("Could not fetch dns records for '{$input}'.");
+            flash()->error("Could not fetch dns records for '{$limitedInput}'.");
 
             return back();
         }
@@ -51,7 +53,7 @@ class HomeController extends Controller
         $dnsInfo = $process->getOutput();
 
         if ($dnsInfo === "") {
-            flash()->error("Could not fetch dns records for '{$input}'.");
+            flash()->error("Could not fetch dns records for '{$limitedInput}'.");
 
             return back();
         }


### PR DESCRIPTION
When no results are found, limit the length of the domain input string to prevent breaking of the page design.

Before (scrollable to the right):
![image](https://user-images.githubusercontent.com/640208/32069986-2463063e-ba8b-11e7-9655-d771715bcf28.png)

After:
![image](https://user-images.githubusercontent.com/640208/32069982-2192cd90-ba8b-11e7-82e9-4d48cbc61638.png)
