### PR TITLE
Append the entered command to the URL

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Services\Commands\CommandChain;
-use Illuminate\Http\Request;
 
 class HomeController extends Controller
 {
@@ -12,12 +11,8 @@ class HomeController extends Controller
         return view('home.index');
     }
 
-    public function submit(Request $request)
+    public function submit($command)
     {
-        $attributes = $request->validate([
-            'command' => 'required',
-        ]);
-
-        return (new CommandChain())->perform($attributes['command']);
+        return (new CommandChain())->perform($command);
     }
 }

--- a/app/Services/Commands/Commands/Clear.php
+++ b/app/Services/Commands/Commands/Clear.php
@@ -14,6 +14,6 @@ class Clear implements Command
 
     public function perform(string $command): Response
     {
-        return back();
+        return redirect('/');
     }
 }

--- a/app/Services/Commands/Commands/DnsLookup.php
+++ b/app/Services/Commands/Commands/DnsLookup.php
@@ -26,11 +26,9 @@ class DnsLookup implements Command
 
             flash()->error($errorText);
 
-            return back();
+            return redirect('/');
         }
 
-        request()->session()->flash('output', htmlentities($dnsRecords));
-
-        return back();
+        return response()->view('home.index', ['output' => htmlentities($dnsRecords)]);
     }
 }

--- a/app/Services/Commands/Commands/Ip.php
+++ b/app/Services/Commands/Commands/Ip.php
@@ -14,8 +14,8 @@ class Ip implements Command
 
     public function perform(string $command): Response
     {
-        request()->session()->flash('output', 'Your ip address is ' . request()->ip() . '.');
+        $output = 'Your ip address is ' . request()->ip() . '.';
 
-        return back();
+        return response()->view('home.index', ['output'=> $output]);
     }
 }

--- a/app/Services/Commands/Commands/Manual.php
+++ b/app/Services/Commands/Commands/Manual.php
@@ -9,7 +9,7 @@ class Manual implements Command
 {
     public function canPerform(string $command): bool
     {
-        return $command === '?';
+        return $command === 'help';
     }
 
     public function perform(string $command): Response
@@ -23,6 +23,6 @@ class Manual implements Command
 
         flash()->message($manualText, 'info');
 
-        return back();
+        return redirect('/');
     }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,4 +1,12 @@
+const form = document.getElementById('form');
 const input = document.getElementById('url');
+
+form.addEventListener('submit', event => {
+    event.preventDefault();
+
+    form.action = input.value;
+    form.submit();
+});
 
 window.addEventListener('click', event => {
     event.stopPropagation();
@@ -18,7 +26,7 @@ window.addEventListener('click', event => {
 
 function isResultTextSelected() {
 
-    if (typeof window.getSelection !== 'undefined' && window.getSelection().toString() !== '') { 
+    if (typeof window.getSelection !== 'undefined' && window.getSelection().toString() !== '') {
         return true;
     }
 

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -9,8 +9,8 @@
     </h1>
 </header>
 <main class="main">
-    @if(session('output'))
-        <pre class="main__results" id="results">{{ session('output') }}</pre>
+    @if(isset($output))
+        <pre class="main__results" id="results">{{ $output }}</pre>
     @endif
 
     @if($errors->has('input'))
@@ -20,9 +20,9 @@
     @endif
     @include('layout._partials.flash')
 
-    <form method="post" action="/">
+    <form id="form" method="post" action="/">
         {{ csrf_field() }}
-        
+
         <span class="carret -green">&rarr;</span>
         <input
             id="url"
@@ -35,11 +35,11 @@
             spellcheck="false"
         />
 
-    </form>  
-</main>   
- 
+    </form>
+</main>
+
 <footer class="footer">
-    © <a href='https://spatie.be/en/opensource'>spatie</a> {{ date('Y') }} — '<kbd>?</kbd>' for help
+    © <a href='https://spatie.be/en/opensource'>spatie</a> {{ date('Y') }} — stuck? type '<kbd>help</kbd>'
 </footer>
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,4 @@
 <?php
 
 Route::get('/', 'HomeController@index')->name('home');
-Route::post('/', 'HomeController@submit')->middleware('logRequest');
+Route::match(['get', 'post'], '/{command}', 'HomeController@submit')->middleware('logRequest');


### PR DESCRIPTION
This PR introduces support for the command being in the URL. It fixes #15.

There were two options to fix this, the easiest being to just use a query string parameter like `https://dnsrecords.io?c=website.com`, but that's kind of ugly IMO. The other option was to have it as a route parameter like `https://dnsrecords.io/website.com`, which looks a lot better, so I ran with that. Open to discuss this though.

Notes:
* Added some JavaScript to intercept the form being submitted and dynamically change the form action.
* Changed routes to match on GETs and POSTs, since it's now possible to browse directly to `https://dnsrecords.io/command` as well as submit the command through the homepage form.
* Removes controller validation for the command. Since the command is now in the URL, it must always be present (otherwise it'll 404 anyway), making the `required` validation unnecessary.
* Changed the various commands to return `redirect()`s and `response()`es, since returning `back()` will lead to undesired results when you're already on`https://dnsrecords.io/website.com` for example.
* Changed from using the session to flash the output to using regular view data. I noticed an issue when flashing where if I browsed to `https://dnsrecords.io/website.com`, and then went back to `https://dnsrecords.io`, I'd get command output printed out.
* Had to change the help command from `?` to `help`, since `https://dnsrecords.io/?` obviously won't work :( I updated the help hint to match.

Also I was going to fix the tests... before I realized you don't have any. :) Maybe that'll be a future PR. ;)