### PR TITLE
append '/' to form action

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -4,7 +4,7 @@ const input = document.getElementById('url');
 form.addEventListener('submit', event => {
     event.preventDefault();
 
-    form.action = input.value.toLowerCase();
+    form.action = '/' + input.value.toLowerCase();
 
     form.submit();
 });


### PR DESCRIPTION
Fixes #22 

This way, people can copy & paste a URL from their browser/wherever without having to think about removing the scheme themselves.