### PR TITLE
Add support for DNS lookup of . (root)

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -14,7 +14,9 @@ class HomeController extends Controller
 
     public function submit($command = null, Request $request)
     {
-        if (!$command && !$command = $request['command']) {
+        $command = $request['command'] ?? $command;
+
+        if (!$command) {
             return $this->index();
         }
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Services\Commands\CommandChain;
+use Illuminate\Http\Request;
 
 class HomeController extends Controller
 {
@@ -11,9 +12,9 @@ class HomeController extends Controller
         return view('home.index');
     }
 
-    public function submit($command = null)
+    public function submit($command = null, Request $request)
     {
-        if (!$command) {
+        if (!$command && !$command = $request['command']) {
             return $this->index();
         }
 

--- a/tests/Feature/DnsLookupTest.php
+++ b/tests/Feature/DnsLookupTest.php
@@ -20,6 +20,10 @@ class DnsLookupTest extends TestCase
         $this
             ->sendCommand('.')
             ->assertSuccessful();
+
+        $this
+            ->post('/', ['command' => '.'])
+            ->assertSee('root-servers.net');
     }
 
     /** @test */


### PR DESCRIPTION
The PR adds support to lookup the `.` (root) domain. The reason this didn't work is because browsers filter out `.` from the URL.

So when no search query is provided in the URL, the post body is checked whether a command is sent there. If so, that command is used as a fallback, which allows `.` to work. It still doesn't allow a shareable URL, but that's not possible as most browsers will filter it out before sending the GET request.