### PR TITLE
Lower the font size for ultra-wide displays

### DIFF
--- a/resources/assets/css/base/html.css
+++ b/resources/assets/css/base/html.css
@@ -11,4 +11,7 @@ html {
         font-size: 1.5vw;
     }
 
+    @media (min-width: 2100px) {
+        font-size: 0.9vw;
+    }
 }


### PR DESCRIPTION
On very wide monitors the font size becomes huge and the information doesn't fit on a single page. 
![image](https://user-images.githubusercontent.com/13980973/43825380-e85614f6-9af4-11e8-8db0-9b340f0fac38.png)

After the fix:
![image](https://user-images.githubusercontent.com/13980973/43825416-fc32265e-9af4-11e8-9eeb-99db77b96bc8.png)

