### PR TITLE
Fix double html-character encoding by removing htmlentities() in DnsLookup

### DIFF
--- a/app/Services/Commands/Commands/DnsLookup.php
+++ b/app/Services/Commands/Commands/DnsLookup.php
@@ -35,6 +35,6 @@ class DnsLookup implements Command
             return redirect('/');
         }
 
-        return response()->view('home.index', ['output' => htmlentities($dnsRecords), 'domain' => $domain ]);
+        return response()->view('home.index', ['output' => $dnsRecords, 'domain' => $domain ]);
     }
 }


### PR DESCRIPTION
This fixes https://github.com/spatie/dnsrecords.io/issues/44

The displayed data is already being character-encoded by Blade:

> By default, Blade {{ }} statements are automatically sent through PHP's htmlspecialchars function to prevent XSS attacks.
https://laravel.com/docs/5.7/blade#displaying-data

So if I'm not mistaken, `htmlentities()` can safely be removed.
