### PR TITLE
Add ability to filter by record type

### DIFF
--- a/app/Services/Commands/Commands/DnsLookup.php
+++ b/app/Services/Commands/Commands/DnsLookup.php
@@ -5,11 +5,25 @@ namespace App\Services\Commands\Commands;
 use App\Services\Commands\Command;
 use App\Services\DnsRecordsRetriever;
 use Exception;
+use Illuminate\Support\Collection;
 use Spatie\Dns\Dns;
 use Symfony\Component\HttpFoundation\Response;
 
 class DnsLookup implements Command
 {
+    const SUPPORTED_RECORD_TYPES = [
+        'A',
+        'AAAA',
+        'CNAME',
+        'NS',
+        'SOA',
+        'MX',
+        'SRV',
+        'TXT',
+        'DNSKEY',
+        'CAA',
+    ];
+
     public function canPerform(string $command): bool
     {
         return true;
@@ -17,10 +31,15 @@ class DnsLookup implements Command
 
     public function perform(string $command): Response
     {
-        $dns = new Dns($command);
-
         try {
-            $dnsRecords = $dns->getRecords();
+            $commandArguments = collect(explode(' ', $command));
+
+            $host = $commandArguments->first();
+            $types = $this->sanitizeTypes($commandArguments->slice(1));
+
+            $dns = new Dns($host);
+
+            $dnsRecords = $dns->getRecords(...$types);
 
             $domain = $dns->getDomain($command);
         } catch (Exception $e) {
@@ -36,5 +55,13 @@ class DnsLookup implements Command
         }
 
         return response()->view('home.index', ['output' => $dnsRecords, 'domain' => $domain ]);
+    }
+
+    protected function sanitizeTypes(Collection $types): Collection {
+        return $types->map(function ($type) {
+            return strtoupper($type);
+        })->filter(function ($type) {
+            return in_array($type, $this->supportedRecordTypes);
+        });
     }
 }

--- a/app/Services/Commands/Commands/Manual.php
+++ b/app/Services/Commands/Commands/Manual.php
@@ -16,6 +16,7 @@ class Manual implements Command
     {
         $manualText = collect([
             'Enter a domain name to retrieve all DNS records.',
+            "Enter '[domain name] [record type]*' to filter by type. Supported types are ".implode(', ', DnsLookup::SUPPORTED_RECORD_TYPES).'.',
             "Enter 'ip' to check your own address.",
             "Enter 'clear' to wipe the screen.",
             "Enter 'doom' to play Doom.",

--- a/tests/Feature/DnsLookupTest.php
+++ b/tests/Feature/DnsLookupTest.php
@@ -11,7 +11,42 @@ class DnsLookupTest extends TestCase
     {
         $this
             ->sendCommand('spatie.be')
-            ->assertSee('<pre class="main__results">');
+            ->assertSee('<pre class="main__results">')
+            ->assertSee('IN A')
+            ->assertSee('IN NS');
+    }
+
+    /** @test */
+    public function it_can_lookup_a_normal_domain_with_filtering_rules_applied()
+    {
+        $this
+            ->sendCommand('spatie.be a soa')
+            ->assertSee('<pre class="main__results">')
+            ->assertSee('IN A')
+            ->assertSee('IN SOA')
+            ->assertDontSee('IN NS');
+    }
+
+    /** @test */
+    public function it_can_lookup_a_normal_domain_with_a_single_applied()
+    {
+        $this
+            ->sendCommand('spatie.be a')
+            ->assertSee('<pre class="main__results">')
+            ->assertSee('IN A')
+            ->assertDontSee('IN SOA')
+            ->assertDontSee('IN NS');
+    }
+
+    /** @test */
+    public function it_doesnt_fail_on_invalid_filtering_rules()
+    {
+        $this
+            ->sendCommand('spatie.be a b c')
+            ->assertSee('<pre class="main__results">')
+            ->assertSee('IN A')
+            ->assertDontSee('IN SOA')
+            ->assertDontSee('IN NS');
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds the ability to filter the DNS records list by type.

Examples of input are `spatie.be A` or `spatie.be A MX`.

For now I've copied the list of supported record types from `Spatie\Dns\Dns` to the `DnsLookup` class since it's not accessible. I will propose a change to [spatie/dns](https://github.com/spatie/dns) for this in that repo.

The tests have become a bit more concrete. I don't think the extra assumptions I made will be an issue (A, NS and SOA records should always exist), but wanted to mention this explicitly.

I'm not sure what's the best 'look' for the URLs yet. Currently it's just `https://dnsrecords.io/spatie.be mx`. An alternative would be `https://dnsrecords.io/spatie.be/mx`, however when multiple filtering rules are applied this would become something like `https://dnsrecords.io/spatie.be/mx/ns` which does not make much sense in my opinion. Ideas about this are welcome :)